### PR TITLE
separate build from sources

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,7 @@ export default defineConfig({
 	plugins: [],
 	server: { host: '0.0.0.0', port: 8000 },
 	clearScreen: false,
+	build: {
+    outDir: './dist',
+  },
 })


### PR DESCRIPTION
This prevents .js files to be created among the sources files.